### PR TITLE
Fixes regex to detect newlines on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If the `language` of code block is `js` or `javascript`, it will be automaticall
 ##### match
 
 Type: `RegExp`<br>
-Default: <code>/^\`{4}(.\*?)\n([\s\S]\*?)\n\`{4}/gm</code>
+Default: <code>/^\`{4}(.\*?)[\n\r]+([\s\S]\*?)[\n\r]+\`{4}/gm</code>
 
 The regular expression we use to find runnable code.
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export default function ({
   sandbox = 'allow-modals allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts',
   prepend = '',
   append = '',
-  match = /^`{4}(.*?)\n([\s\S]*?)\n`{4}/gm,
+  match = /^`{4}(.*?)[\n\r]+([\s\S]*?)[\n\r]+`{4}/gm,
   showSourceCode = true,
   surfaceAPI = ['Prism', 'fetch'],
   parseContent = defaultParseContent


### PR DESCRIPTION
This PR fixes #7 by modifying the match regex to find newlines on Windows (\r).